### PR TITLE
Fixed material-ui and createPalette related bugs

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "@types/react": "^16.0.5",
     "@types/react-dom": "^15.5.4",
     "@types/react-router-dom": "^4.0.7",
-    "material-ui": "next",
+    "material-ui": "^1.0.0-beta.10",
     "material-ui-icons": "^1.0.0-beta.5",
     "react": "^15.6.1",
     "react-dom": "^15.6.1",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { BrowserRouter as Router, Route, Switch } from 'react-router-dom';
 
 import { MuiThemeProvider, createMuiTheme } from 'material-ui/styles';
-import createPalette from 'material-ui/styles/palette';
+import createPalette from 'material-ui/styles/createPalette';
 
 import Header from './components/Header/Header';
 import Splash from './components/Splash/Splash';

--- a/yarn.lock
+++ b/yarn.lock
@@ -3303,14 +3303,14 @@ map-obj@^1.0.0, map-obj@^1.0.1:
   resolved "https://registry.yarnpkg.com/map-obj/-/map-obj-1.0.1.tgz#d933ceb9205d82bdcf4886f6742bdc2b4dea146d"
 
 material-ui-icons@^1.0.0-beta.5:
-  version "1.0.0-beta.5"
-  resolved "https://registry.yarnpkg.com/material-ui-icons/-/material-ui-icons-1.0.0-beta.5.tgz#ff012ffd1f6c6e08d65ba91ecdc667286931b45c"
+  version "1.0.0-beta.10"
+  resolved "https://registry.yarnpkg.com/material-ui-icons/-/material-ui-icons-1.0.0-beta.10.tgz#d3ddf80bc8fbcfbe93be1519a852e7ea79bd01d9"
   dependencies:
     recompose "^0.24.0"
 
-material-ui@next:
-  version "1.0.0-beta.9"
-  resolved "https://registry.yarnpkg.com/material-ui/-/material-ui-1.0.0-beta.9.tgz#97f8a3c727232c0466e1f154c22204abc75ce2e4"
+material-ui@^1.0.0-beta.10:
+  version "1.0.0-beta.10"
+  resolved "https://registry.yarnpkg.com/material-ui/-/material-ui-1.0.0-beta.10.tgz#8aaa5a8cf9cee366f42c31c7fb6d8a2d37039404"
   dependencies:
     babel-runtime "^6.26.0"
     brcast "^3.0.1"
@@ -3325,6 +3325,7 @@ material-ui@next:
     prop-types "^15.5.10"
     react-event-listener "^0.5.0"
     react-jss "^7.1.0"
+    react-popper "^0.7.2"
     react-scrollbar-size "^2.0.0"
     react-transition-group "^2.2.0"
     recompose "^0.24.0"
@@ -3956,6 +3957,10 @@ pkg-dir@^2.0.0:
   dependencies:
     find-up "^2.1.0"
 
+popper.js@^1.10.8:
+  version "1.12.5"
+  resolved "https://registry.yarnpkg.com/popper.js/-/popper.js-1.12.5.tgz#229e4dea01629e1f1a1e26991ffade5024220fa6"
+
 portfinder@^1.0.9:
   version "1.0.13"
   resolved "https://registry.yarnpkg.com/portfinder/-/portfinder-1.0.13.tgz#bb32ecd87c27104ae6ee44b5a3ccbf0ebb1aede9"
@@ -4484,6 +4489,14 @@ react-jss@^7.1.0:
     jss-preset-default "^3.0.0"
     prop-types "^15.5.8"
     theming "^1.1.0"
+
+react-popper@^0.7.2:
+  version "0.7.2"
+  resolved "https://registry.yarnpkg.com/react-popper/-/react-popper-0.7.2.tgz#5daa821eadc6f2ca802176d7be271d0f03f25f58"
+  dependencies:
+    is-equal-shallow "^0.1.3"
+    popper.js "^1.10.8"
+    prop-types "^15.5.10"
 
 react-router-dom@^4.2.2:
   version "4.2.2"


### PR DESCRIPTION
While trying to build the spa, I ran into a couple problems:

```
./src/App.tsx
(5,27): error TS2307: Cannot find module 'material-ui/styles/palette'.
```
The module is called [`createPalette` ](https://github.com/callemall/material-ui/blob/v1-beta/src/styles/createPalette.js), not `palette`. Changing the line as such removed this error from the console.

```
node_modules/material-ui/Chip/Chip.d.ts(4,18): error TS2430: Interface 'ChipProps' incorrectly extends interface 'HTMLAttributes<HTMLDivElement>'.
  Types of property 'tabIndex' are incompatible.
    Type 'string | number | undefined' is not assignable to type 'number | undefined'.
      Type 'string' is not assignable to type 'number | undefined'.
```

This error was caused by using an out of date version of material-ui. [There was an issue that was fixed a few days ago](https://github.com/callemall/material-ui/issues/8135) regarding this, so I updated the version of material-ui, which removed this error.

After making these changes, there are no more errors in the js console, and the index page renders.