### PR TITLE
Forward default exports for components to the folder

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -4,10 +4,10 @@ import { BrowserRouter as Router, Route, Switch } from 'react-router-dom';
 import createMuiTheme from 'material-ui/styles/createMuiTheme';
 import MuiThemeProvider from 'material-ui/styles/MuiThemeProvider';
 
-import Header from './components/Header/Header';
-import Login from './components/Login/Login';
-import Logout from './components/Logout/Logout';
-import MemberChallengeList from './components/MemberChallengeList/MemberChallengeList';
+import Header from './components/Header';
+import Login from './components/Login';
+import Logout from './components/Logout';
+import MemberChallengeList from './components/MemberChallengeList';
 
 import './App.css';
 

--- a/src/components/Header/Header.jsx
+++ b/src/components/Header/Header.jsx
@@ -18,7 +18,7 @@ import MenuIcon from 'material-ui-icons/Menu';
 import { sideNavToggle } from '../../actions/sideNav';
 import { snackbarClose, snackbarRemove } from '../../actions/snackbars';
 
-import SideNav from '../SideNav/SideNav';
+import SideNav from '../SideNav';
 
 const styles = theme => ({
   appTitle: {

--- a/src/components/Header/index.js
+++ b/src/components/Header/index.js
@@ -1,0 +1,1 @@
+export { default } from './Header';

--- a/src/components/Login/index.js
+++ b/src/components/Login/index.js
@@ -1,0 +1,1 @@
+export { default } from './Login';

--- a/src/components/Logout/index.js
+++ b/src/components/Logout/index.js
@@ -1,0 +1,1 @@
+export { default } from './Logout';

--- a/src/components/MemberChallengeList/index.js
+++ b/src/components/MemberChallengeList/index.js
@@ -1,0 +1,1 @@
+export { default } from './MemberChallengeList';

--- a/src/components/SideNav/index.js
+++ b/src/components/SideNav/index.js
@@ -1,0 +1,1 @@
+export { default } from './SideNav';


### PR DESCRIPTION
This'll help keep our component imports from being too redundant or extra long.